### PR TITLE
ci: removing linkage-monitor from the required checks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -31,7 +31,6 @@ branchProtectionRules:
   requiredStatusCheckContexts:
   - "dependencies (8)"
   - "dependencies (11)"
-  - "linkage-monitor"
   - "lint"
   - "clirr"
   - "units (8)"

--- a/README.md
+++ b/README.md
@@ -22,20 +22,20 @@ If you are using Maven, add this to your pom.xml file:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-policy-troubleshooter</artifactId>
-  <version>0.3.1</version>
+  <version>0.3.2</version>
 </dependency>
 ```
 
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-compile 'com.google.cloud:google-cloud-policy-troubleshooter:0.3.1'
+compile 'com.google.cloud:google-cloud-policy-troubleshooter:0.3.2'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-policy-troubleshooter" % "0.3.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-policy-troubleshooter" % "0.3.2"
 ```
 
 ## Authentication


### PR DESCRIPTION
Linkage Monitor is no longer needed, because the Libraries BOM synchronizes with Google Cloud BOM and the shared dependencies BOM https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/2137